### PR TITLE
Include math-util.h in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@
 #include "remote-server.h"
 #include "batch-image-render.h"
 #include "gui-util.h"
+#include "math-util.h"
 
 #ifdef HAVE_GNET
 #include "cluster-model.h"


### PR DESCRIPTION
Fixes build failure due to implicit declaration of `math_init`:

```
main.c:84:5: error: implicit declaration of function 'math_init' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

as reported here: https://trac.macports.org/ticket/70701